### PR TITLE
Use dependency replace feature for root cargo project

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,17 +1,3 @@
-[[bin]]
-name = "tcx"
-path = "src/main.rs"
-
-[package]
-name = "tcx"
-version = "0.2.0"
-authors = ["Neal Xu <imxuneal@gmail.com>"]
-edition = "2018"
-autobenches = false
-
-[dependencies]
-tcx-lib = { path = "tcx-lib" }
-
 [workspace]
 members = [
     "crypto",
@@ -19,17 +5,3 @@ members = [
     "bitcoin-cash",
     "tcx-lib",
 ]
-
-[dev-dependencies]
-criterion = "0.2"
-hex-literal = "0.2"
-
-[target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.8"
-
-[profile.release]
-lto = true
-debug = true
-overflow-checks = true
-
-

--- a/rust/bitcoin-cash/Cargo.toml
+++ b/rust/bitcoin-cash/Cargo.toml
@@ -9,8 +9,8 @@ tcx-crypto = { path = "../crypto" }
 tcx-chain = { path = "../chain" }
 bch_addr = "0.1.0"
 hex-literal = "0.1.4"
-bitcoin = { path = "../../../rust-bitcoin"}
-secp256k1 = { path = "../../../rust-secp256k1"}
+bitcoin = "0.18"
+secp256k1 = "0.12"
 tiny-bip39 = "0.6.0"
 bitcoin_hashes = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
@@ -21,3 +21,6 @@ num-bigint = "0.2"
 num-traits = "0.2"
 num-integer = "0.1"
 byteorder = "1.3.2"
+
+[replace]
+"secp256k1:0.12.3" = { git = 'https://github.com/rust-bitcoin/rust-secp256k1.git' }

--- a/rust/chain/Cargo.toml
+++ b/rust/chain/Cargo.toml
@@ -6,11 +6,14 @@ edition = "2018"
 
 [dependencies]
 tcx-crypto = { path = "../crypto" }
-bitcoin = { path = "../../../rust-bitcoin"}
-secp256k1 = { path = "../../../rust-secp256k1"}
+bitcoin = "0.18"
+secp256k1 = "0.12"
 tiny-bip39 = "0.6.0"
 bitcoin_hashes = "0.3.2"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
 failure = "0.1.5"
+
+[replace]
+"secp256k1:0.12.3" = { git = 'https://github.com/rust-bitcoin/rust-secp256k1.git' }

--- a/rust/crypto/Cargo.toml
+++ b/rust/crypto/Cargo.toml
@@ -23,5 +23,8 @@ pbkdf2 = "0.3.0"
 memzero = "0.1"
 bitcoin_hashes = "0.3.2"
 crypto-mac = "0.7.0"
-secp256k1 = { path = "../../../rust-secp256k1"}
+secp256k1 = "0.12"
 failure = "0.1.5"
+
+[replace]
+"secp256k1:0.12.3" = { git = 'https://github.com/rust-bitcoin/rust-secp256k1.git' }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,0 @@
-
-fn main() {
-    println!("main method");
-}


### PR DESCRIPTION
changes:
1. 使用 replace 功能替换 secp256k1, 无需使用手动克隆方式
2. 删除根目录下的项目

ref: https://doc.rust-lang.org/cargo/reference/manifest.html#the-replace-section
