### PR TITLE
Fix signature with same lock_hash

### DIFF
--- a/tcx-chain/src/keystore/mod.rs
+++ b/tcx-chain/src/keystore/mod.rs
@@ -126,6 +126,12 @@ impl Keystore {
         ))
     }
 
+    pub fn from_mnemonic(mnemonic: &str, password: &str, metadata: Metadata) -> Result<Keystore> {
+        Ok(Keystore::Hd(HdKeystore::from_mnemonic(
+            mnemonic, password, metadata,
+        )?))
+    }
+
     pub fn id(&self) -> String {
         self.store().id.to_string()
     }

--- a/tcx-ckb/src/transaction_helper.rs
+++ b/tcx-ckb/src/transaction_helper.rs
@@ -46,17 +46,19 @@ impl Witness {
         ]))
     }
 
-    fn is_empty(&self) -> Result<bool> {
-        Ok(hex_to_bytes(&self.lock)?.len() == 0
-            && hex_to_bytes(&self.input_type)?.len() == 0
-            && hex_to_bytes(&self.output_type)?.len() == 0)
+    fn is_empty(value: &str) -> bool {
+        ((value.starts_with("0x") || value.starts_with("0x")) && value.len() == 2)
+            || value.len() == 0
     }
 
-    pub fn try_to_string(&self) -> Result<String> {
-        if self.is_empty()? {
-            return Ok("0x".to_owned());
+    pub fn to_raw(&self) -> Result<Vec<u8>> {
+        if Witness::is_empty(&self.lock)
+            && Witness::is_empty(&self.input_type)
+            && Witness::is_empty(&self.output_type)
+        {
+            Ok(vec![])
         } else {
-            return Ok(format!("0x{}", hex::encode(self.serialize()?)));
+            self.serialize()
         }
     }
 }
@@ -149,24 +151,13 @@ mod tests {
     }
 
     #[test]
-    fn to_string() {
+    fn witness_to_raw() {
         let witness = Witness {
             lock: "0x".to_owned(),
             input_type: "0x".to_owned(),
             output_type: "0x".to_owned(),
         };
 
-        assert_eq!(witness.try_to_string().unwrap(), "0x");
-
-        let witness = Witness {
-            lock: "0x".to_owned(),
-            input_type: "0x10".to_owned(),
-            output_type: "0x20".to_owned(),
-        };
-
-        assert_eq!(
-            witness.try_to_string().unwrap(),
-            "0x1a00000010000000100000001500000001000000100100000020"
-        );
+        assert_eq!("", hex::encode(witness.to_raw().unwrap()));
     }
 }


### PR DESCRIPTION
ckb-sdk-js 的 sign_transaction 如果是同一个 lock_hash, 第二个输入的 witness 如果是空的对象。签名时serialize 成空的 u8数组。