### PR TITLE
docs: change the image type of gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TokenCoreX
 
 [![Build status](https://travis-ci.org/consenlabs/token-core.svg?branch=dev)](https://travis-ci.org/consenlabs/token-core)
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/imtoken-wallet/token-core)
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/imtoken-wallet/token-core)
 
 Next generation core inside imToken Wallet.
 


### PR DESCRIPTION
Change the image type to get a better experience on high dpi devices.

![image](https://user-images.githubusercontent.com/33575974/115350946-49593600-a1e8-11eb-8bc4-0c1879f41c31.png)

![image](https://user-images.githubusercontent.com/33575974/115350891-3b0b1a00-a1e8-11eb-9d50-2bf879cb8300.png)
